### PR TITLE
Add native-tls feature to tokio-tungstenite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.127"
 thiserror = "1.0.63"
 tokio = { version = "1.39.3", features = ["full"] }
-tokio-tungstenite = "0.23.1"
+tokio-tungstenite = { version = "0.23.1", features = ["native-tls"] }
 url = "2.5.2"
 hmac = "0.12.1"
 sha2 = "0.10.8"


### PR DESCRIPTION
Add native-tls feature to tokio-tungstenite to allow connecting to a server using TLS.