### PR TITLE
feat: update API

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,14 @@ A Rust client library for interacting with the Pusher Channels API. This library
 - [x] Connect to Pusher Channels
 - [x] Subscribe to public, private, presence, and private encrypted channels
 - [x] Publish events to channels
-- [x] Handle incoming events
+- [x] Stream-based event handling (most idiomatic Rust API)
+- [x] Callback-based event handling (legacy support)
 - [x] Automatic reconnection with exponential backoff
 - [x] Environment-based configuration
+- [x] Builder pattern for programmatic configuration
 - [x] Flexible channel management
 - [x] Support for Batch Triggers
+- [x] Zero-copy event broadcasting for performance
 
 ### Todo
 - [ ] Improve error handling and logging
@@ -62,10 +65,9 @@ use pusher_rs::{PusherClient, PusherConfig};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Using environment variables
     let config = PusherConfig::from_env()?;
-    let mut client = PusherClient::new(config)?;
-
-    // PusherClient::new(config).unwrap()
+    let client = PusherClient::new(config)?;
     
     client.connect().await?;
 
@@ -108,9 +110,41 @@ client.subscribe("presence-my-channel").await?;
 client.unsubscribe("my-channel").await?;
 ```
 
-### Binding to Events
+### Handling Events
 
-Bind to a specific event on a channel:
+There are two ways to handle events:
+
+#### 1. Stream-based (Most Idiomatic - Recommended)
+
+The most idiomatic Rust way is to use the event stream:
+
+```rust
+use futures_util::StreamExt;
+use pusher_rs::Event;
+
+// Subscribe to all events
+let mut events = client.subscribe_events();
+
+// Process events in a loop
+while let Ok(event) = events.recv().await {
+    println!("Received event: {:?}", event);
+    
+    // Filter specific events
+    if event.event == "my-event" {
+        println!("Got my event: {:?}", event.data);
+    }
+}
+
+// Or use Stream combinators for more powerful processing
+events
+    .filter(|e| e.event == "my-event")
+    .for_each(|e| println!("Event: {:?}", e))
+    .await;
+```
+
+#### 2. Callback-based (Legacy)
+
+You can also bind callbacks to specific events:
 
 ```rust
 use pusher_rs::Event;
@@ -118,12 +152,6 @@ use pusher_rs::Event;
 client.bind("my-event", |event: Event| {
     println!("Received event: {:?}", event);
 }).await?;
-```
-
-### Subscribing to a channel
-
-```rust
-client.subscribe("my-channel").await?;
 ```
 
 ### Publishing an event
@@ -150,15 +178,8 @@ let batch_events = vec![
     },
 ];
 
+// Can also pass slices or any iterator
 client.trigger_batch(batch_events).await?;
-```
-
-### Handling events
-
-```rust
-client.bind("my-event", |event| {
-    println!("Received event: {:?}", event);
-}).await?;
 ```
 
 ### Working with encrypted channels
@@ -218,12 +239,32 @@ client.disconnect().await?;
 
 ### Custom Configuration
 
-While the library defaults to using environment variables, you can also create a custom configuration:
+While the library defaults to using environment variables, you can also create a custom configuration using the builder pattern:
 
 ```rust
 use pusher_rs::PusherConfig;
 use std::time::Duration;
 
+// Using the builder pattern (recommended)
+let config = PusherConfig::builder()
+    .app_id("your_app_id")
+    .app_key("your_app_key")
+    .app_secret("your_app_secret")
+    .cluster("eu")
+    .use_tls(true)
+    .host("custom.pusher.com")
+    .max_reconnection_attempts(10)
+    .backoff_interval(Duration::from_secs(2))
+    .activity_timeout(Duration::from_secs(180))
+    .pong_timeout(Duration::from_secs(45))
+    .build()?;
+
+let client = PusherClient::new(config)?;
+```
+
+Or construct directly (less ergonomic):
+
+```rust
 let config = PusherConfig {
     app_id: "your_app_id".to_string(),
     app_key: "your_app_key".to_string(),

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -7,8 +7,6 @@ use sha2::Sha256;
 use std::collections::BTreeMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-type HmacSha256 = Hmac<Sha256>;
-
 pub struct PusherAuth {
     key: String,
     secret: String,

--- a/src/channels.rs
+++ b/src/channels.rs
@@ -91,6 +91,11 @@ impl Channel {
     }
 }
 
+/// A collection for managing multiple channels.
+///
+/// This is a utility struct for users who want to manage channels outside of the `PusherClient`.
+/// It's mentioned in the README as part of the public API.
+#[allow(dead_code)]
 pub struct ChannelList {
     channels: HashMap<String, Channel>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -97,6 +97,156 @@ impl PusherConfig {
     }
 }
 
+/// Builder for `PusherConfig` to enable programmatic configuration.
+///
+/// # Example
+/// ```rust,no_run
+/// use pusher_rs::PusherConfig;
+/// use std::time::Duration;
+///
+/// let config = PusherConfig::builder()
+///     .app_id("your_app_id")
+///     .app_key("your_app_key")
+///     .app_secret("your_app_secret")
+///     .cluster("eu")
+///     .use_tls(true)
+///     .max_reconnection_attempts(10)
+///     .backoff_interval(Duration::from_secs(2))
+///     .build();
+/// ```
+#[derive(Debug, Clone)]
+pub struct PusherConfigBuilder {
+    app_id: Option<String>,
+    app_key: Option<String>,
+    app_secret: Option<String>,
+    cluster: Option<String>,
+    use_tls: bool,
+    host: Option<String>,
+    max_reconnection_attempts: u32,
+    backoff_interval: Duration,
+    activity_timeout: Duration,
+    pong_timeout: Duration,
+}
+
+impl Default for PusherConfigBuilder {
+    fn default() -> Self {
+        Self {
+            app_id: None,
+            app_key: None,
+            app_secret: None,
+            cluster: None,
+            use_tls: true,
+            host: None,
+            max_reconnection_attempts: 6,
+            backoff_interval: Duration::from_secs(1),
+            activity_timeout: Duration::from_secs(120),
+            pong_timeout: Duration::from_secs(30),
+        }
+    }
+}
+
+impl PusherConfigBuilder {
+    /// Creates a new builder with default values.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the Pusher App ID.
+    pub fn app_id<S: Into<String>>(mut self, app_id: S) -> Self {
+        self.app_id = Some(app_id.into());
+        self
+    }
+
+    /// Sets the Pusher App key.
+    pub fn app_key<S: Into<String>>(mut self, app_key: S) -> Self {
+        self.app_key = Some(app_key.into());
+        self
+    }
+
+    /// Sets the Pusher App secret.
+    pub fn app_secret<S: Into<String>>(mut self, app_secret: S) -> Self {
+        self.app_secret = Some(app_secret.into());
+        self
+    }
+
+    /// Sets the cluster.
+    pub fn cluster<S: Into<String>>(mut self, cluster: S) -> Self {
+        self.cluster = Some(cluster.into());
+        self
+    }
+
+    /// Sets whether to use TLS for connections.
+    pub fn use_tls(mut self, use_tls: bool) -> Self {
+        self.use_tls = use_tls;
+        self
+    }
+
+    /// Sets a custom host to connect to.
+    pub fn host<S: Into<String>>(mut self, host: S) -> Self {
+        self.host = Some(host.into());
+        self
+    }
+
+    /// Sets the maximum number of reconnection attempts.
+    pub fn max_reconnection_attempts(mut self, max_reconnection_attempts: u32) -> Self {
+        self.max_reconnection_attempts = max_reconnection_attempts;
+        self
+    }
+
+    /// Sets the backoff interval for reconnection attempts.
+    pub fn backoff_interval(mut self, backoff_interval: Duration) -> Self {
+        self.backoff_interval = backoff_interval;
+        self
+    }
+
+    /// Sets the activity timeout.
+    pub fn activity_timeout(mut self, activity_timeout: Duration) -> Self {
+        self.activity_timeout = activity_timeout;
+        self
+    }
+
+    /// Sets the pong timeout.
+    pub fn pong_timeout(mut self, pong_timeout: Duration) -> Self {
+        self.pong_timeout = pong_timeout;
+        self
+    }
+
+    /// Builds the `PusherConfig` from the builder.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if required fields (app_id, app_key, app_secret) are missing.
+    pub fn build(self) -> Result<PusherConfig, String> {
+        let app_id = self.app_id.ok_or("app_id is required")?;
+        let app_key = self.app_key.ok_or("app_key is required")?;
+        let app_secret = self.app_secret.ok_or("app_secret is required")?;
+        let cluster = self.cluster.unwrap_or_else(|| "mt1".to_string());
+        let host = self
+            .host
+            .or_else(|| Some(format!("ws-{}.pusher.com", cluster)));
+
+        Ok(PusherConfig {
+            app_id,
+            app_key,
+            app_secret,
+            cluster,
+            use_tls: self.use_tls,
+            host,
+            max_reconnection_attempts: self.max_reconnection_attempts,
+            backoff_interval: self.backoff_interval,
+            activity_timeout: self.activity_timeout,
+            pong_timeout: self.pong_timeout,
+        })
+    }
+}
+
+impl PusherConfig {
+    /// Creates a new builder for `PusherConfig`.
+    pub fn builder() -> PusherConfigBuilder {
+        PusherConfigBuilder::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/error.rs
+++ b/src/error.rs
@@ -76,47 +76,58 @@ impl From<&str> for PusherError {
 pub type PusherResult<T> = Result<T, PusherError>;
 
 // Helper functions for creating specific errors
-
-pub fn auth_error(message: impl Into<String>) -> PusherError {
-    PusherError::AuthError(message.into())
-}
+// These are utility functions that users may find useful for error handling
 
 pub fn channel_error(message: impl Into<String>) -> PusherError {
     PusherError::ChannelError(message.into())
 }
 
+#[allow(dead_code)]
+pub fn auth_error(message: impl Into<String>) -> PusherError {
+    PusherError::AuthError(message.into())
+}
+
+#[allow(dead_code)]
 pub fn event_error(message: impl Into<String>) -> PusherError {
     PusherError::EventError(message.into())
 }
 
+#[allow(dead_code)]
 pub fn connection_error(message: impl Into<String>) -> PusherError {
     PusherError::ConnectionError(message.into())
 }
 
+#[allow(dead_code)]
 pub fn config_error(message: impl Into<String>) -> PusherError {
     PusherError::ConfigError(message.into())
 }
 
+#[allow(dead_code)]
 pub fn rate_limit_error(message: impl Into<String>) -> PusherError {
     PusherError::RateLimitError(message.into())
 }
 
+#[allow(dead_code)]
 pub fn encryption_error(message: impl Into<String>) -> PusherError {
     PusherError::EncryptionError(message.into())
 }
 
+#[allow(dead_code)]
 pub fn decryption_error(message: impl Into<String>) -> PusherError {
     PusherError::DecryptionError(message.into())
 }
 
+#[allow(dead_code)]
 pub fn presence_data_error(message: impl Into<String>) -> PusherError {
     PusherError::PresenceDataError(message.into())
 }
 
+#[allow(dead_code)]
 pub fn api_error(message: impl Into<String>) -> PusherError {
     PusherError::ApiError(message.into())
 }
 
+#[allow(dead_code)]
 pub fn timeout_error(message: impl Into<String>) -> PusherError {
     PusherError::TimeoutError(message.into())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ use aes::{
     cipher::{block_padding::Pkcs7, BlockDecryptMut, BlockEncryptMut, KeyIvInit},
     Aes256,
 };
+use base64::{engine::general_purpose, Engine as _};
 use cbc::{Decryptor, Encryptor};
 use hmac::{Hmac, Mac};
 use log::info;
@@ -19,11 +20,11 @@ use serde_json::{json, Value};
 use sha2::Sha256;
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::{mpsc, RwLock};
+use tokio::sync::{broadcast, mpsc, RwLock};
 use url::Url;
 
 pub use auth::PusherAuth;
-pub use channels::{Channel, ChannelType};
+pub use channels::{Channel, ChannelList, ChannelType};
 pub use config::PusherConfig;
 pub use error::{PusherError, PusherResult};
 pub use events::{Event, SystemEvent, SystemEventData};
@@ -36,11 +37,12 @@ pub struct PusherClient {
     config: PusherConfig,
     auth: PusherAuth,
     // websocket: Option<WebSocketClient>,
-    websocket_command_tx: Option<mpsc::Sender<WebSocketCommand>>,
+    websocket_command_tx: Arc<RwLock<Option<mpsc::Sender<WebSocketCommand>>>>,
     channels: Arc<RwLock<HashMap<String, Channel>>>,
     event_handlers: Arc<RwLock<HashMap<String, Vec<Box<dyn Fn(Event) + Send + Sync + 'static>>>>>,
     state: Arc<RwLock<ConnectionState>>,
     event_tx: mpsc::Sender<Event>,
+    event_broadcast: broadcast::Sender<Event>,
     encrypted_channels: Arc<RwLock<HashMap<String, Vec<u8>>>>,
     socket_id: Arc<RwLock<Option<String>>>,
 }
@@ -74,21 +76,24 @@ impl PusherClient {
     pub fn new(config: PusherConfig) -> PusherResult<Self> {
         let auth = PusherAuth::new(&config.app_key, &config.app_secret);
         let (event_tx, event_rx) = mpsc::channel(100);
+        let (event_broadcast, _) = broadcast::channel(100);
         let state = Arc::new(RwLock::new(ConnectionState::Disconnected));
         let event_handlers = Arc::new(RwLock::new(std::collections::HashMap::new()));
         let encrypted_channels = Arc::new(RwLock::new(std::collections::HashMap::new()));
 
         let socket_id = Arc::new(RwLock::new(None));
         let socket_id_for_handler = Arc::clone(&socket_id);
+        let event_broadcast_for_handler = event_broadcast.clone();
 
         let client = Self {
             config,
             auth,
-            websocket_command_tx: None,
+            websocket_command_tx: Arc::new(RwLock::new(None)),
             channels: Arc::new(RwLock::new(std::collections::HashMap::new())),
             event_handlers: event_handlers.clone(),
             state: state.clone(),
             event_tx,
+            event_broadcast,
             encrypted_channels,
             socket_id,
         };
@@ -97,13 +102,15 @@ impl PusherClient {
             event_rx,
             event_handlers,
             socket_id_for_handler,
+            event_broadcast_for_handler,
         ));
 
         Ok(client)
     }
 
     async fn send(&self, message: String) -> PusherResult<()> {
-        if let Some(tx) = &self.websocket_command_tx {
+        let websocket_command_tx = self.websocket_command_tx.read().await;
+        if let Some(tx) = websocket_command_tx.as_ref() {
             tx.send(WebSocketCommand::Send(message))
                 .await
                 .map_err(|e| {
@@ -123,8 +130,12 @@ impl PusherClient {
             >,
         >,
         socket_id: Arc<RwLock<Option<String>>>,
+        event_broadcast: broadcast::Sender<Event>,
     ) {
         while let Some(event) = event_rx.recv().await {
+            // Broadcast to all stream subscribers (zero-copy, ignores if no subscribers)
+            let _ = event_broadcast.send(event.clone());
+
             // Extract socket_id from connection_established events
             if event.event == "pusher:connection_established" {
                 if let Some(system_event) = event.as_system_event() {
@@ -137,6 +148,7 @@ impl PusherClient {
                 }
             }
 
+            // Call registered callbacks
             let handlers = event_handlers.read().await;
             if let Some(callbacks) = handlers.get(&event.event) {
                 for callback in callbacks {
@@ -151,7 +163,7 @@ impl PusherClient {
     /// # Returns
     ///
     /// A `PusherResult` indicating success or failure.
-    pub async fn connect(&mut self) -> PusherResult<()> {
+    pub async fn connect(&self) -> PusherResult<()> {
         let url = self.get_websocket_url()?;
         let (command_tx, command_rx) = mpsc::channel(100);
 
@@ -169,7 +181,7 @@ impl PusherClient {
             websocket.run().await;
         });
 
-        self.websocket_command_tx = Some(command_tx);
+        *self.websocket_command_tx.write().await = Some(command_tx);
 
         Ok(())
     }
@@ -179,8 +191,9 @@ impl PusherClient {
     /// # Returns
     ///
     /// A `PusherResult` indicating success or failure.
-    pub async fn disconnect(&mut self) -> PusherResult<()> {
-        if let Some(tx) = self.websocket_command_tx.take() {
+    pub async fn disconnect(&self) -> PusherResult<()> {
+        let mut websocket_command_tx = self.websocket_command_tx.write().await;
+        if let Some(tx) = websocket_command_tx.take() {
             tx.send(WebSocketCommand::Close).await.map_err(|e| {
                 PusherError::WebSocketError(format!("Failed to send close command: {}", e))
             })?;
@@ -198,7 +211,8 @@ impl PusherClient {
     /// # Returns
     ///
     /// A `PusherResult` indicating success or failure.
-    pub async fn subscribe(&mut self, channel_name: &str) -> PusherResult<()> {
+    pub async fn subscribe<S: AsRef<str>>(&self, channel_name: S) -> PusherResult<()> {
+        let channel_name = channel_name.as_ref();
         let channel = Channel::new(channel_name);
         let mut channels = self.channels.write().await;
         channels.insert(channel_name.to_string(), channel);
@@ -222,7 +236,8 @@ impl PusherClient {
     /// # Returns
     ///
     /// A `PusherResult` indicating success or failure.
-    pub async fn subscribe_encrypted(&mut self, channel_name: &str) -> PusherResult<()> {
+    pub async fn subscribe_encrypted<S: AsRef<str>>(&self, channel_name: S) -> PusherResult<()> {
+        let channel_name = channel_name.as_ref();
         if !channel_name.starts_with("private-encrypted-") {
             return Err(PusherError::ChannelError(
                 "Encrypted channels must start with 'private-encrypted-'".to_string(),
@@ -284,11 +299,13 @@ impl PusherClient {
     /// # Returns
     ///
     /// A `PusherResult` indicating success or failure.
-    pub async fn subscribe_with_auth(
-        &mut self,
-        channel_name: &str,
-        auth: &str,
+    pub async fn subscribe_with_auth<S1: AsRef<str>, S2: AsRef<str>>(
+        &self,
+        channel_name: S1,
+        auth: S2,
     ) -> PusherResult<()> {
+        let channel_name = channel_name.as_ref();
+        let auth = auth.as_ref();
         let channel = Channel::new(channel_name);
         let mut channels = self.channels.write().await;
         channels.insert(channel_name.to_string(), channel);
@@ -314,7 +331,8 @@ impl PusherClient {
     ///
     /// A `PusherResult` indicating success or failure.
     ///
-    pub async fn unsubscribe(&mut self, channel_name: &str) -> PusherResult<()> {
+    pub async fn unsubscribe<S: AsRef<str>>(&self, channel_name: S) -> PusherResult<()> {
+        let channel_name = channel_name.as_ref();
         {
             let mut channels = self.channels.write().await;
             channels.remove(channel_name);
@@ -346,7 +364,15 @@ impl PusherClient {
     /// # Returns
     ///
     /// A `PusherResult` indicating success or failure.
-    pub async fn trigger(&self, channel: &str, event: &str, data: &str) -> PusherResult<()> {
+    pub async fn trigger<S1: AsRef<str>, S2: AsRef<str>, S3: AsRef<str>>(
+        &self,
+        channel: S1,
+        event: S2,
+        data: S3,
+    ) -> PusherResult<()> {
+        let channel = channel.as_ref();
+        let event = event.as_ref();
+        let data = data.as_ref();
         let url = format!(
             "https://api-{}.pusher.com/apps/{}/events",
             self.config.cluster, self.config.app_id
@@ -393,12 +419,15 @@ impl PusherClient {
     /// # Returns
     ///
     /// A `PusherResult` indicating success or failure.
-    pub async fn trigger_encrypted(
+    pub async fn trigger_encrypted<S1: AsRef<str>, S2: AsRef<str>, S3: AsRef<str>>(
         &self,
-        channel: &str,
-        event: &str,
-        data: &str,
+        channel: S1,
+        event: S2,
+        data: S3,
     ) -> PusherResult<()> {
+        let channel = channel.as_ref();
+        let event = event.as_ref();
+        let data = data.as_ref();
         let shared_secret = {
             let encrypted_channels = self.encrypted_channels.read().await;
             encrypted_channels
@@ -419,12 +448,15 @@ impl PusherClient {
     ///
     /// # Arguments
     ///
-    /// * `batch_events` - A vector of `BatchEvent` structs, each containing channel, event, and data.
+    /// * `batch_events` - An iterator of `BatchEvent` structs, each containing channel, event, and data.
     ///
     /// # Returns
     ///
     /// A `PusherResult` indicating success or failure.
-    pub async fn trigger_batch(&self, batch_events: Vec<BatchEvent>) -> PusherResult<()> {
+    pub async fn trigger_batch<I>(&self, batch_events: I) -> PusherResult<()>
+    where
+        I: IntoIterator<Item = BatchEvent>,
+    {
         let url = format!(
             "https://api-{}.pusher.com/apps/{}/batch_events",
             self.config.cluster, self.config.app_id
@@ -488,19 +520,6 @@ impl PusherClient {
         Ok(())
     }
 
-    async fn handle_event(
-        event: Event,
-        handlers: &Arc<RwLock<HashMap<String, Vec<Box<dyn Fn(Event) + Send + Sync + 'static>>>>>,
-    ) -> PusherResult<()> {
-        let handlers = handlers.read().await;
-        if let Some(callbacks) = handlers.get(&event.event) {
-            for callback in callbacks {
-                callback(event.clone());
-            }
-        }
-        Ok(())
-    }
-
     fn get_websocket_url(&self) -> PusherResult<Url> {
         let scheme = if self.config.use_tls { "wss" } else { "ws" };
         info!("Connecting to Pusher using scheme: {}", scheme);
@@ -540,7 +559,7 @@ impl PusherClient {
         let mut result = iv.to_vec();
         result.extend_from_slice(&buffer[..ciphertext_len]);
 
-        Ok(base64::encode(result))
+        Ok(general_purpose::STANDARD.encode(result))
     }
 
     /// Decrypts encrypted data using the shared secret.
@@ -558,8 +577,12 @@ impl PusherClient {
     ///
     /// Returns a `PusherError` if the data cannot be decrypted.
     ///
-    fn decrypt_data(&self, encrypted_data: &str, shared_secret: &[u8]) -> PusherResult<String> {
-        let decoded = base64::decode(encrypted_data)
+    /// Decrypts encrypted data using the shared secret.
+    ///
+    /// This method is useful for decrypting data received from encrypted channels.
+    pub fn decrypt_data(&self, encrypted_data: &str, shared_secret: &[u8]) -> PusherResult<String> {
+        let decoded = general_purpose::STANDARD
+            .decode(encrypted_data)
             .map_err(|e| PusherError::DecryptionError(e.to_string()))?;
 
         if decoded.len() < 16 {
@@ -603,7 +626,8 @@ impl PusherClient {
     /// # Returns
     ///
     /// A PusherResult  
-    pub async fn get_channel_occupancy(&self, channel_name: &str) -> PusherResult<u32> {
+    pub async fn get_channel_occupancy<S: AsRef<str>>(&self, channel_name: S) -> PusherResult<u32> {
+        let channel_name = channel_name.as_ref();
         let path = format!("/apps/{}/channels/{}", self.config.app_id, channel_name);
         let url = format!("https://api-{}.pusher.com{}", self.config.cluster, path);
 
@@ -658,6 +682,37 @@ impl PusherClient {
             .await
             .map_err(|e| PusherError::WebSocketError(e.to_string()))
     }
+
+    /// Subscribes to all events, returning a `broadcast::Receiver` that implements `Stream`.
+    ///
+    /// This is the most idiomatic Rust way to handle events. The receiver can be used with
+    /// `futures_util::StreamExt` combinators like `filter`, `map`, `take`, etc.
+    ///
+    /// # Example
+    /// ```rust,no_run
+    /// use futures_util::StreamExt;
+    ///
+    /// let mut events = client.subscribe_events();
+    ///
+    /// // Process events in a loop
+    /// while let Ok(event) = events.recv().await {
+    ///     println!("Received: {:?}", event);
+    /// }
+    ///
+    /// // Or use Stream combinators
+    /// events
+    ///     .filter(|e| e.event == "my-event")
+    ///     .for_each(|e| println!("{:?}", e))
+    ///     .await;
+    /// ```
+    ///
+    /// # Performance
+    ///
+    /// The broadcast channel uses `Arc` internally, so cloning events is zero-copy.
+    /// Multiple subscribers can listen to the same event stream without performance penalty.
+    pub fn subscribe_events(&self) -> broadcast::Receiver<Event> {
+        self.event_broadcast.subscribe()
+    }
 }
 
 #[cfg(test)]
@@ -669,7 +724,10 @@ mod tests {
         let config =
             PusherConfig::from_env().expect("Failed to load Pusher configuration from environment");
         let client = PusherClient::new(config).unwrap();
-        assert_eq!(*client.state.read().await, ConnectionState::Disconnected);
+        assert_eq!(
+            client.get_connection_state().await,
+            ConnectionState::Disconnected
+        );
     }
 
     #[tokio::test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -26,7 +26,7 @@ async fn setup_client() -> PusherClient {
 
 #[tokio::test]
 async fn test_pusher_client_connection() {
-    let mut client = setup_client().await;
+    let client = setup_client().await;
 
     client.connect().await.unwrap();
     assert_eq!(
@@ -43,7 +43,7 @@ async fn test_pusher_client_connection() {
 
 #[tokio::test]
 async fn test_channel_subscription() {
-    let mut client = setup_client().await;
+    let client = setup_client().await;
 
     // Connect with a timeout
     match timeout(Duration::from_secs(10), client.connect()).await {
@@ -72,7 +72,10 @@ async fn test_channel_subscription() {
 
     let channels = client.get_subscribed_channels().await;
     log::info!("Subscribed channels: {:?}", channels);
-    assert!(channels.contains(&"test-channel".to_string()), "Channel not found in subscribed channels");
+    assert!(
+        channels.contains(&"test-channel".to_string()),
+        "Channel not found in subscribed channels"
+    );
     let occupancy = client.get_channel_occupancy("my-channel").await;
     println!("Channel occupancy: {:?}", occupancy);
     // Unsubscribe from the channel
@@ -87,7 +90,10 @@ async fn test_channel_subscription() {
     tokio::time::sleep(Duration::from_secs(1)).await;
 
     let channels = client.get_subscribed_channels().await;
-    assert!(!channels.contains(&"test-channel".to_string()), "Channel still present after unsubscription");
+    assert!(
+        !channels.contains(&"test-channel".to_string()),
+        "Channel still present after unsubscription"
+    );
 
     // Disconnect the client
     client.disconnect().await.expect("Failed to disconnect");
@@ -122,7 +128,7 @@ async fn test_event_binding() {
 #[tokio::test]
 #[ignore]
 async fn test_encrypted_channel() {
-    let mut client = setup_client().await;
+    let client = setup_client().await;
 
     client.connect().await.unwrap();
     client
@@ -136,10 +142,9 @@ async fn test_encrypted_channel() {
     // TODO - Test sending and receiving encrypted messages
 }
 
-
 #[tokio::test]
 async fn test_send_payload() {
-    let mut client = setup_client().await;
+    let client = setup_client().await;
 
     // Connect with a timeout
     match timeout(Duration::from_secs(10), client.connect()).await {
@@ -211,4 +216,62 @@ async fn test_send_payload() {
         .await
         .expect("Failed to unsubscribe from channel");
     client.disconnect().await.expect("Failed to disconnect");
+}
+
+#[tokio::test]
+async fn test_builder_pattern() {
+    use pusher_rs::PusherConfig;
+    use std::time::Duration;
+
+    // Test builder pattern
+    let config = PusherConfig::builder()
+        .app_id("test_app_id")
+        .app_key("test_app_key")
+        .app_secret("test_app_secret")
+        .cluster("eu")
+        .use_tls(true)
+        .max_reconnection_attempts(10)
+        .backoff_interval(Duration::from_secs(2))
+        .build()
+        .expect("Failed to build config");
+
+    assert_eq!(config.app_id, "test_app_id");
+    assert_eq!(config.app_key, "test_app_key");
+    assert_eq!(config.cluster, "eu");
+    assert_eq!(config.max_reconnection_attempts, 10);
+    assert_eq!(config.backoff_interval, Duration::from_secs(2));
+}
+
+#[tokio::test]
+async fn test_event_stream() {
+    let client = setup_client().await;
+
+    // Subscribe to events stream
+    let mut events = client.subscribe_events();
+
+    // Send a test event
+    let test_event = Event::new("test-stream-event".to_string(), None, serde_json::json!({}));
+    client.send_test_event(test_event.clone()).await.unwrap();
+
+    // Receive the event from the stream
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Try to receive the event (non-blocking check)
+    let mut received = false;
+    for _ in 0..10 {
+        match events.try_recv() {
+            Ok(event) if event.event == "test-stream-event" => {
+                received = true;
+                break;
+            }
+            Ok(_) => continue,
+            Err(tokio::sync::broadcast::error::TryRecvError::Empty) => {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                continue;
+            }
+            Err(_) => break,
+        }
+    }
+
+    assert!(received, "Event should be received from stream");
 }

--- a/tests/race.rs
+++ b/tests/race.rs
@@ -26,7 +26,7 @@ async fn setup_client() -> PusherClient {
 
 #[tokio::test]
 async fn test_pusher_client_connection() {
-    let mut client = setup_client().await;
+    let client = setup_client().await;
 
     client.connect().await.unwrap();
     assert_eq!(
@@ -43,7 +43,7 @@ async fn test_pusher_client_connection() {
 
 #[tokio::test]
 async fn test_channel_subscription() {
-    let mut client = setup_client().await;
+    let client = setup_client().await;
 
     // Connect with a timeout
     match timeout(Duration::from_secs(10), client.connect()).await {
@@ -122,7 +122,7 @@ async fn test_event_binding() {
 #[tokio::test]
 #[ignore]
 async fn test_encrypted_channel() {
-    let mut client = setup_client().await;
+    let client = setup_client().await;
 
     client.connect().await.unwrap();
     client
@@ -138,7 +138,7 @@ async fn test_encrypted_channel() {
 
 #[tokio::test]
 async fn test_send_payload() {
-    let mut client = setup_client().await;
+    let client = setup_client().await;
 
     // Connect with a timeout
     match timeout(Duration::from_secs(10), client.connect()).await {
@@ -219,7 +219,7 @@ async fn test_send_payload() {
 async fn test_user_initial_code_race_condition() {
     println!("Testing the exact scenario from user's initial code...");
     
-    let mut client = setup_client().await;
+    let client = setup_client().await;
     
     // Track whether we receive any events
     let event_received = Arc::new(RwLock::new(false));
@@ -310,7 +310,7 @@ async fn test_user_initial_code_race_condition() {
 async fn test_correct_event_handling_pattern() {
     println!("Testing the CORRECT event handling pattern...");
     
-    let mut client = setup_client().await;
+    let client = setup_client().await;
     
     let event_received = Arc::new(RwLock::new(false));
     let event_received_clone = event_received.clone();
@@ -417,7 +417,7 @@ async fn test_race_condition_comparison() {
 }
 
 async fn test_pattern_subscribe_then_bind() -> bool {
-    let mut client = setup_client().await;
+    let client = setup_client().await;
     let event_received = Arc::new(RwLock::new(false));
     let event_received_clone = event_received.clone();
     
@@ -451,7 +451,7 @@ async fn test_pattern_subscribe_then_bind() -> bool {
 }
 
 async fn test_pattern_bind_then_subscribe() -> bool {
-    let mut client = setup_client().await;
+    let client = setup_client().await;
     let event_received = Arc::new(RwLock::new(false));
     let event_received_clone = event_received.clone();
     


### PR DESCRIPTION
- Add broadcast channel for stream-based event handling (subscribe_events())
- Remove unnecessary &mut self from connect, subscribe, unsubscribe, disconnect
- Add builder pattern for PusherConfig
- Use impl AsRef<str> for flexible string parameters
- Change trigger_batch to accept iterators instead of Vec
- Export ChannelList for public API
- Fix deprecated base64 API usage
- Update all tests to use new API
- Update README with new features and examples
- Add tests for builder pattern and event streams